### PR TITLE
Version 1.0 Changes

### DIFF
--- a/Display.cpp
+++ b/Display.cpp
@@ -14,7 +14,7 @@ hd44780_I2Cexp lcd;
 
 // LcdSetup()
 // Initializes the LCD and prints the initial splash screen displayed during setup state
-bool LcdSetup()
+bool LcdSetup(char* response)
 {
   int status;
   bool result = false;
@@ -33,12 +33,19 @@ bool LcdSetup()
   lcd.print(VERSION_MINOR);
 
   // Print display line 3
-  lcd.setCursor(0,2);
-  lcd.print("    Initializing    ");
+  //lcd.setCursor(0,2);
+  //lcd.print("    Initializing    ");
 
   // Print display line 4
-  lcd.setCursor(0,3);
+  lcd.setCursor(0,2);
   lcd.print("  Connecting Scale  ");
+
+  // Print out the scale response
+  lcd.setCursor(0,3);
+  lcd.print("                    ");
+  lcd.setCursor(0,3);
+  lcd.print(response);
+
 
   result = true;
 
@@ -120,15 +127,18 @@ void Trickle(float measured, float assigned)
   lcd.print("      Trickler      ");
 
   clearLine(1);
+  lcd.setCursor(0,1);
   lcd.print("Expected = 0.01-0.10");
 
   // Print display line 3
   clearLine(2);
+  lcd.setCursor(0,2);
   lcd.print("Measured = ");
   lcd.print(measured, 4);
   
   // Print display line 4
   clearLine(3);
+  lcd.setCursor(0,3);
   lcd.print("Assigned = ");
   lcd.print(assigned, 4);
 }
@@ -142,15 +152,18 @@ void CalibrationComplete(float bulk, float kernel)
   lcd.print(" Calibration  Ended ");
   
   clearLine(1);
+  lcd.setCursor(0,1);
   lcd.print(" Disable to Proceed ");
 
   // Print display line 3
   clearLine(2);
+  lcd.setCursor(0,2);
   lcd.print("    Bulk = ");
   lcd.print(bulk);
 
   // Print display line 4
   clearLine(3);
+  lcd.setCursor(0,3);
   lcd.print("  Kernel = ");
   lcd.print(kernel, 3);
   lcd.setCursor(17,3);
@@ -166,6 +179,7 @@ void IdleScreen(float targetWeight, float errorMargin)
 
   // Print display line 3
   clearLine(2);
+  lcd.setCursor(0,2);
   lcd.print("   Target = ");
   lcd.print(targetWeight);
 
@@ -184,6 +198,7 @@ void ReadyScreen(float targetWeight, float errorMargin)
 
   // Print display line 3
   clearLine(2);
+  lcd.setCursor(0,2);
   lcd.print("   Target = ");
   lcd.print(targetWeight);
 
@@ -202,6 +217,7 @@ void BulkScreen(float targetWeight, float errorMargin)
 
   // Print display line 3
   clearLine(2);
+  lcd.setCursor(0,2);
   lcd.print("   Target = ");
   lcd.print(targetWeight);
 
@@ -220,6 +236,7 @@ void TrickleScreen(float targetWeight, float errorMargin)
 
   // Print display line 3
   clearLine(2);
+  lcd.setCursor(0,2);
   lcd.print("   Target = ");
   lcd.print(targetWeight);
 
@@ -231,53 +248,92 @@ void TrickleScreen(float targetWeight, float errorMargin)
 
 void GoodChargeScreen(float targetWeight, float finalWeight, int duration, float errorMargin)
 {
+  // Print the 1st display line
+  lcd.setCursor(0,0);
+  lcd.print(LINE1);
+
   // Print the 2nd display line
   lcd.setCursor(0,1);
   lcd.print(" Trickle Completed! ");
 
   // Clear and print 3rd display line
   clearLine(2);
+  lcd.setCursor(0,2);
   lcd.print("  Dispensed = ");
   lcd.print(finalWeight);
 
   // Clear and then print the 4th display line
   clearLine(3);
+  lcd.setCursor(0,3);
   lcd.print(" Throw Time = ");
   lcd.print(duration);
 }
 
 void OverthrowScreen(float targetWeight, float finalWeight, int duration, float errorMargin)
 {
+  // Print the 1st display line
+  lcd.setCursor(0,0);
+  lcd.print(LINE1);
+
   // Print 2nd display line
   lcd.setCursor(0,1);
   lcd.print(" OVERTHROW WARNING! ");
 
   // Clear and print 3rd display line
   clearLine(2);
+  lcd.setCursor(0,2);
   lcd.print("  Dispensed = ");
   lcd.print(finalWeight);
 
   // Clear and then print the 4th display line
   clearLine(3);
+  lcd.setCursor(0,3);
   lcd.print(" Throw Time = ");
   lcd.print(duration);
 }
 
 void StaleChargeScreen(float targetWeight, float finalWeight, int duration, float errorMargin)
 {
+  // Print the 1st display line
+  lcd.setCursor(0,0);
+  lcd.print(LINE1);
+
   // Print 2nd display line
   lcd.setCursor(0,1);
   lcd.print("  CHANGE DETECTED!  ");
 
   // Clear and print 3rd display line
   clearLine(2);
+  lcd.setCursor(0,2);
   lcd.print("  Dispensed = ");
   lcd.print(finalWeight);
 
   // Clear and then print the 4th display line
   clearLine(3);
+  lcd.setCursor(0,3);
   lcd.print("Push ^ To Add Kernel");
-  lcd.print(duration);
+}
+
+void LowChargeScreen(float targetWeight, float finalWeight, int duration, float errorMargin)
+{
+  // Print the 1st display line
+  lcd.setCursor(0,0);
+  lcd.print(LINE1);
+
+  // Print 2nd display line
+  lcd.setCursor(0,1);
+  lcd.print("UNDERTHROW DETECTED!");
+
+  // Clear and print 3rd display line
+  clearLine(2);
+  lcd.setCursor(0,2);
+  lcd.print("  Dispensed = ");
+  lcd.print(finalWeight);
+
+  // Clear and then print the 4th display line
+  clearLine(3);
+  lcd.setCursor(0,3);
+  lcd.print("Push ^ To Add Kernel");
 }
 
 // noErrorTopLines()

--- a/Display.h
+++ b/Display.h
@@ -16,8 +16,8 @@
 //#include "Steppers.h"
 
 // Current software version
-#define VERSION_MAJOR 0
-#define VERSION_MINOR 9
+#define VERSION_MAJOR 1
+#define VERSION_MINOR 0
 // Display constants
 #define LCD_COLS 20
 #define LCD_ROWS 4
@@ -25,7 +25,7 @@
 // LcdSetup()
 // Initializes the LCD and prints the initial splash screen displayed during setup state
 // Returns true on success, or false on failure
-bool LcdSetup();
+bool LcdSetup(char* response);
 void WaitingToCalibrate();
 void CalibrationScreen();
 void StageOneBulk(float measured, float assigned);
@@ -41,6 +41,7 @@ void TrickleScreen(float targetWeight, float errorMargin);
 void GoodChargeScreen(float targetWeight, float finalWeight, int duration, float errorMargin);
 void OverthrowScreen(float targetWeight, float finalWeight, int duration, float errorMargin);
 void StaleChargeScreen(float targetWeight, float finalWeight, int duration, float errorMargin);
+void LowChargeScreen(float targetWeight, float finalWeight, int duration, float errorMargin);
 
 void noErrorTopLines(float errorMargin);
 void eraseTopLines();

--- a/PrintedPrecisionTrickler.ino
+++ b/PrintedPrecisionTrickler.ino
@@ -80,7 +80,8 @@ void setup() {
   digitalWrite(BULK_ENABLE, HIGH);
 
   // Initialize the display
-  LcdSetup();
+  char response[20] = "No Response Received";
+  LcdSetup(response);
   Serial.println("Display initialized");
 
   // Initialize the scale

--- a/Scale.cpp
+++ b/Scale.cpp
@@ -3,6 +3,7 @@
 
 // Include the header file
 #include "Scale.h"
+#include "Display.h"
 
 // Persistent weight variables
 float latestWeight;
@@ -24,10 +25,19 @@ void SetupScale()
     delay(50);
   } while(!Serial1.available());
 
+  char response[20] = "                    ";
+  char newChar;
+  int i = 0;
+
   Serial.print("Scale serial number is '");
   while(Serial1.available())
   {
-    Serial.print(Serial1.read());
+    newChar = Serial1.read();
+    Serial.print(newChar);
+
+    response[i] = newChar;
+    i++;
+    LcdSetup(response);
   }
   Serial.println("'");
 }

--- a/StateMachine.cpp
+++ b/StateMachine.cpp
@@ -1290,7 +1290,7 @@ int EvaluateState()
   else
   {
     // Handle extreme underthrow (this should never happen)
-    if(weightDiff > 1)
+    if(weightDiff > 5)
     {
       // Reset LEDs before exiting evaluate (yellow plus red for extreme underthrow)
       LowChargeScreen(targetWeight, evaluateWeight, elapsedTime, errorMargin);

--- a/StateMachine.cpp
+++ b/StateMachine.cpp
@@ -847,7 +847,7 @@ int DispenseState()
         return EVALUATE_STATE;
       }
       // Fine tune calibration on close calls to avoid overthrows
-      else if(weightDiff < 0.1)
+      else if(weightDiff < 0.2)
       {
         Serial.println("Second bulk pulse too close to target, adjusting calibration");
         secondBulkCalibration = secondBulkCalibration - 0.005;

--- a/StateMachine.cpp
+++ b/StateMachine.cpp
@@ -335,7 +335,7 @@ int CalibrationState()
     // Indicate calibration fail with LEDs
     digitalWrite(GREEN_LED, LOW);
     digitalWrite(YELLOW_LED, LOW);
-    digitalWrite(RED_LED, HIGH);
+    digitalWrite(RED_LED, LOW);
 
     Trickle(kernelAverage, GetKernelWeight());
 
@@ -711,8 +711,21 @@ int DispenseState()
   // Gather the current weight and calculate our weight difference stuff
   dispenseWeight = StableWeight(LONG);
   float weightDiff = targetWeight - dispenseWeight;
+  float startingWeightDiff = weightDiff;
 
   startTime = millis();
+
+  // First skip straight to evaluate if weightDiff is negative
+  if(weightDiff <= 0)
+  {
+    return EVALUATE_STATE;
+  }
+
+  // If the weightDiff is greater than 250gr, skip straight to evaluate because something is wrong
+  if(weightDiff > 250)
+  {
+    return EVALUATE_STATE;
+  }
 
   // Do first stage bulk dispense if we need 10+ grains
   if(weightDiff > 10)
@@ -732,15 +745,22 @@ int DispenseState()
     // Collect weight again to evaluate next steps
     dispenseWeight = StableWeight(SHORT);
     weightDiff = targetWeight - dispenseWeight;
+    float dispenseTotal = startingWeightDiff - weightDiff;
+
+    // Less than 1gr was dispensed, skip straight to eval state
+    if(dispenseTotal < 1)
+    {
+      return EVALUATE_STATE;
+    }
 
     // Getting too close to target case, small calibration adjustment
-    if(weightDiff < (0.02 * targetWeight))
+    else if(weightDiff < (0.02 * targetWeight))
     {
       Serial.println("First bulk pulse too close to target, making slight calibration adjustment");
       smallIncreaseBulkCalibration();
     }
     // Overthrow case, adjust calibration
-    if(weightDiff < (-1.2 * errorMargin))
+    else if(weightDiff < (-1.2 * errorMargin))
     {
       Serial.println("First bulk pulse overthrow, exiting to evaluate");
       increaseBulkCalibration();
@@ -818,13 +838,26 @@ int DispenseState()
       // Perfect throw case
       else if(weightDiff < 0.01)
       {
-        // Go to evaluate state
+        // Go to evaluate state after adjusting calibration
         Serial.println("2nd bulk pulse hit exact targetWeight, exiting to evaluate");
+        secondBulkCalibration = secondBulkCalibration - 0.005;
+        Serial.print("secondBulkCalibration reduced by 0.005, new value = ");
+        Serial.println(secondBulkCalibration);
 
         return EVALUATE_STATE;
       }
-      // Handle extreme underthrow first
-      else if(weightDiff > targetWeight * 0.5)
+      // Fine tune calibration on close calls to avoid overthrows
+      else if(weightDiff < 0.1)
+      {
+        Serial.println("Second bulk pulse too close to target, adjusting calibration");
+        secondBulkCalibration = secondBulkCalibration - 0.005;
+        Serial.print("secondBulkCalibration reduced by 0.005, new value = ");
+        Serial.println(secondBulkCalibration);
+
+        // Do not exit dispense state in this instance
+      }
+      // Handle extreme underthrow case (relative to starting point, not relative to target weight now that re-trickle was added)
+      else if(weightDiff > startingWeightDiff * 0.5)
       {
         Serial.println("Extreme underthrow error during second bulk pulse");
         
@@ -878,13 +911,26 @@ int DispenseState()
     // Perfect throw case
     else if(weightDiff < 0.01)
     {
-      // Go to evaluate state
+      // Go to evaluate state after adjusting calibration
       Serial.println("2nd bulk pulse hit exact targetWeight, exiting to evaluate");
+      secondBulkCalibration = secondBulkCalibration - 0.005;
+      Serial.print("secondBulkCalibration reduced by 0.005, new value = ");
+      Serial.println(secondBulkCalibration);
 
       return EVALUATE_STATE;
     }
-    // Handle extreme underthrow first
-    else if(weightDiff > targetWeight * 0.5)
+    // Fine tune calibration on close calls to avoid overthrows
+    else if(weightDiff < 0.1)
+    {
+      Serial.println("Second bulk pulse too close to target, adjusting calibration");
+      secondBulkCalibration = secondBulkCalibration - 0.005;
+      Serial.print("secondBulkCalibration reduced by 0.005, new value = ");
+      Serial.println(secondBulkCalibration);
+
+      // Do not exit dispense state in this instance
+    }
+    // Handle extreme underthrow case (relative to starting point, not relative to target weight now that re-trickle was added)
+    else if(weightDiff > startingWeightDiff * 0.5)
     {
       Serial.println("Extreme underthrow error during second bulk pulse");
         
@@ -907,6 +953,12 @@ int DispenseState()
   // Now do a final trickle, on first entry we already have a current weight and weightDiff from above sections of code
   while(isEnabled())
   {
+    // Do not allow it to trickle more than 5gr of powder
+    if(weightDiff > 5)
+    {
+      return DISPENSE_STATE;
+    }
+    
     // If weightDiff is one kernel or less, re-measure the weight just in case
     if(weightDiff < (1.2 * errorMargin))
     {
@@ -949,6 +1001,16 @@ int DispenseState()
 
       // Immediately proceed to evaluate state
       return EVALUATE_STATE;
+    }
+
+    // Adjust kernel target for longer trickles
+    if(weightDiff > 0.75)
+    {
+      kernels = kernels - 3;
+    }
+    else if(weightDiff > 0.4)
+    {
+      kernels = kernels - 1;
     }
 
     Serial.print("Fine trickling '");
@@ -1028,7 +1090,7 @@ int DispenseState()
     else
     {
       // Handle extreme underthrow
-      if(weightDiff > targetWeight * 0.5)
+      if(weightDiff > 2)
       {
         Serial.println("Extreme underthrow error during trickle");
 
@@ -1135,8 +1197,8 @@ int EvaluateState()
     if(tmpWeight != evaluateWeight)
     {
       // Case 1.1 - tmpWeight indicates user has removed the shot glass
-      // Verify weight is less than -500, since shot glass will weigh at least that much
-      if(tmpWeight > 500)
+      // Verify weight is less than -200 or greater than 500 (overflow error), since shot glass will weigh at least that much
+      if(tmpWeight > 500 || tmpWeight < -200)
       {
         // Reset the evaluation flags
         firstEvaluate = true;
@@ -1228,21 +1290,21 @@ int EvaluateState()
   else
   {
     // Handle extreme underthrow (this should never happen)
-    if(weightDiff > targetWeight * 0.5)
+    if(weightDiff > 1)
     {
-      // Reset evaluation flags since we will exit Evaluate state
-      firstEvaluate = true;
-      evaluateUpdate = false;
-
-      // Reset LEDs before exiting evaluate
+      // Reset LEDs before exiting evaluate (yellow plus red for extreme underthrow)
+      LowChargeScreen(targetWeight, evaluateWeight, elapsedTime, errorMargin);
       digitalWrite(GREEN_LED, LOW);
-      digitalWrite(YELLOW_LED, LOW);
-      digitalWrite(RED_LED, LOW);
+      digitalWrite(YELLOW_LED, HIGH);
+      digitalWrite(RED_LED, HIGH);
+
+      // Set evaluateUpdate flag
+      evaluateUpdate = true;
 
       Serial.println("Extreme underthrow error during evaluate");
-      return READY_STATE;
+      return EVALUATE_STATE;
     }
-    // Underthrow by more than 0.02gr (which tests are good throw above), but less than the calibrated kernel weight
+    // Underthrow by more than 0.02gr (which tests as a good throw above), but less than the calibrated kernel weight
     else if(weightDiff <= (1.2 * kernelWeight))
     {
       // Reset LEDS before exiting evaluate (both green and yellow illuminated for this case)
@@ -1260,7 +1322,7 @@ int EvaluateState()
     else
     {
       // Reset LEDs before exiting evaluate (yellow only for true underthrow)
-      StaleChargeScreen(targetWeight, evaluateWeight, elapsedTime, errorMargin);
+      LowChargeScreen(targetWeight, evaluateWeight, elapsedTime, errorMargin);
       digitalWrite(GREEN_LED, LOW);
       digitalWrite(YELLOW_LED, HIGH);
       digitalWrite(RED_LED, LOW);
@@ -1341,6 +1403,12 @@ bool downPressed()
 // Does a bulk throw, including the retraction at the end
 bool bulkThrow(float grains)
 {
+  // Do not allow dispensing of more than 250 grains of powder
+  if(grains > 250)
+  {
+    return false;
+  }
+
   // Bulk dispense the requested number of grains of powder
   BulkDispense(grains, (1.5 * RECOVERY_STEPS));
 
@@ -1412,6 +1480,16 @@ bool waitForTrickle()
     if(!isEnabled())
     {
       Serial.println("Enable toggled off during trickle, stopping motors and ending their movement");
+      StopMotors();
+
+      EndTrickle();
+      EndBulk();
+      return false;
+    }
+    // Stop the trickle if the weight goes below zero at any time
+    if(StableWeight(50) < 0)
+    {
+      Serial.println("Cup removed during trickle, stopping motors and ending their movement");
       StopMotors();
 
       EndTrickle();


### PR DESCRIPTION
- Fix display of dispense time during evaluate state
- Catch if bulk dispense did not actually dispense anything to avoid repeated re-tries
- Do not allow system to attempt to trickle more than 5gr of powder
- Stop trickle immediately if cup is removed during the trickle dispense
- Tuning for the trickle dispensing target based on size of trickle
- Added additional underthrow screen for clarity
- Version number incremented